### PR TITLE
Scrollbars automatically hidden

### DIFF
--- a/Src/MoneyFox.Windows/Views/AboutView.xaml
+++ b/Src/MoneyFox.Windows/Views/AboutView.xaml
@@ -26,7 +26,8 @@
         <ScrollViewer Margin="12,12,12,0"
                       Grid.Row="1"
                       EntranceNavigationTransitionInfo.IsTargetElement="True"
-                      HorizontalAlignment="Center">
+                      HorizontalAlignment="Center"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel>
 
                 <StackPanel>

--- a/Src/MoneyFox.Windows/Views/ModifyAccountView.xaml
+++ b/Src/MoneyFox.Windows/Views/ModifyAccountView.xaml
@@ -24,7 +24,8 @@
         </userControls:PageHeader>
 
         <ScrollViewer Grid.Row="1"
-                      HorizontalScrollMode="Auto">
+                      HorizontalScrollMode="Auto"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Margin="12,0,12,0"
                         EntranceNavigationTransitionInfo.IsTargetElement="True">
                 <TextBox Text="{Binding SelectedAccount.Name, Mode=TwoWay}"

--- a/Src/MoneyFox.Windows/Views/ModifyPaymentView.xaml
+++ b/Src/MoneyFox.Windows/Views/ModifyPaymentView.xaml
@@ -46,7 +46,7 @@
 
         <Grid Grid.Row="1"
               EntranceNavigationTransitionInfo.IsTargetElement="True">
-            <ScrollViewer>
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <StackPanel Margin="12,0,12,0">
                     <ComboBox Header="{Binding AccountHeader}"
                               HorizontalAlignment="Stretch"

--- a/Src/MoneyFox.Windows/Views/StatisticCategorySummaryView.xaml
+++ b/Src/MoneyFox.Windows/Views/StatisticCategorySummaryView.xaml
@@ -64,7 +64,7 @@
             <TextBlock Grid.Row="0" Text="{Binding Title}"
                        Style="{StaticResource DeemphasizedBodyTextBlockStyle}" />
 
-            <ScrollViewer Grid.Row="1">
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
                 <controls:AlternatingRowListView OddRowBackground="{StaticResource ListViewBackgroundOddBrush}"
                                                  EvenRowBackground="{StaticResource ListViewBackgroundEvenBrush}"
                                                  ItemsSource="{Binding CategorySummary}"

--- a/Src/MoneyFox.Windows/Views/UserControls/CategoryListUserControl.xaml
+++ b/Src/MoneyFox.Windows/Views/UserControls/CategoryListUserControl.xaml
@@ -50,7 +50,7 @@
                  Margin="5,0,5,0"
                  x:Uid="SearchHeader"
                  Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        <ScrollViewer Margin="0,7,0,0" Grid.Row="1">
+        <ScrollViewer Margin="0,7,0,0" Grid.Row="1" ScrollViewer.VerticalScrollBarVisibility="Auto">
             <controls:AlternatingRowListView OddRowBackground="{StaticResource ListViewBackgroundOddBrush}"
                                              EvenRowBackground="{StaticResource ListViewBackgroundEvenBrush}"
                                              ItemsSource="{Binding Categories}"


### PR DESCRIPTION
Fixed issue #751, scrollbars are shown only if the content exceeds the page's margins.